### PR TITLE
Ensure database is created on application startup

### DIFF
--- a/Backer.Web/Program.cs
+++ b/Backer.Web/Program.cs
@@ -1,10 +1,12 @@
 using Backer.Application;
 using Backer.Core.Interfaces;
 using Backer.Infrastructure;
+using Backer.Infrastructure.Data;
 using Backer.Infrastructure.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.EntityFrameworkCore;
 
 using System.Text;
 
@@ -56,6 +58,12 @@ builder.Services.AddAuthentication(options =>
 #endregion JWT
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    dbContext.Database.Migrate();
+}
 
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary
- ensure the application applies pending Entity Framework Core migrations during startup so the database is created automatically when missing

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d91628e0288327a0a22f42c033252d