### PR TITLE
Implement PBKDF2 hashing and add auth tests

### DIFF
--- a/Backer.Utilities/TokenUtility.cs
+++ b/Backer.Utilities/TokenUtility.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 using System.Security.Cryptography;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
@@ -37,55 +38,118 @@ namespace Backer.Utilities
             return new JwtSecurityTokenHandler().WriteToken(token);
         }
 
-        /// Hashes a password using PBKDF2 with a random salt.
-        /// The returned string contains both the salt and hash in Base64 format.
+        private const int SaltSize = 16;
+        private const int KeySize = 32;
+        private const int Iterations = 100_000;
+        private const byte HashVersion = 1;
+
+        /// <summary>
+        /// Hashes a password using PBKDF2 with a random salt and embeds the
+        /// metadata required for verification in a Base64 encoded payload.
+        /// </summary>
+        /// <param name="password">The plaintext password to hash.</param>
+        /// <returns>A Base64 encoded string containing the hashing metadata, salt and derived key.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="password"/> is null.</exception>
         public static string HashPassword(string password)
         {
-            // Convert the integer to a stringk
-            string passwordString = password.ToString();
-            // Use SHA-256 to hash the password string
-            using (SHA256 sha256Hash = SHA256.Create())
+            if (password is null)
             {
-                byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(passwordString));
-                // Convert byte array to a string
-                StringBuilder builder = new StringBuilder();
-                for (int i = 0; i < bytes.Length; i++)
-                {
-                    builder.Append(bytes[i].ToString("x2"));
-                }
-                return builder.ToString();
+                throw new ArgumentNullException(nameof(password));
+            }
+
+            byte[] salt = RandomNumberGenerator.GetBytes(SaltSize);
+
+            using var pbkdf2 = new Rfc2898DeriveBytes(password, salt, Iterations, HashAlgorithmName.SHA256);
+            byte[] derivedKey = pbkdf2.GetBytes(KeySize);
+
+            byte[] payload = new byte[1 + sizeof(int) + SaltSize + KeySize];
+            payload[0] = HashVersion;
+            BinaryPrimitives.WriteInt32BigEndian(payload.AsSpan(1, sizeof(int)), Iterations);
+            Buffer.BlockCopy(salt, 0, payload, 1 + sizeof(int), SaltSize);
+            Buffer.BlockCopy(derivedKey, 0, payload, 1 + sizeof(int) + SaltSize, KeySize);
+
+            return Convert.ToBase64String(payload);
+        }
+
+        /// <summary>
+        /// Verifies a plaintext password against either the new PBKDF2 based payload
+        /// or the legacy SHA-256 hex encoded hash.
+        /// </summary>
+        /// <param name="password">The plaintext password to validate.</param>
+        /// <param name="storedHash">The stored hash to validate against.</param>
+        /// <returns><c>true</c> when the password matches the stored hash; otherwise <c>false</c>.</returns>
+        public static bool VerifyPassword(string password, string storedHash)
+        {
+            if (string.IsNullOrWhiteSpace(password) || string.IsNullOrWhiteSpace(storedHash))
+            {
+                return false;
+            }
+
+            if (TryVerifyPbkdf2(password, storedHash, out bool verified))
+            {
+                return verified;
+            }
+
+            string legacyHash = HashPasswordLegacy(password);
+            return string.Equals(legacyHash, storedHash, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryVerifyPbkdf2(string password, string storedHash, out bool verified)
+        {
+            verified = false;
+
+            byte[] hashBytes;
+            try
+            {
+                hashBytes = Convert.FromBase64String(storedHash);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            int expectedLength = 1 + sizeof(int) + SaltSize + KeySize;
+            if (hashBytes.Length != expectedLength || hashBytes[0] != HashVersion)
+            {
+                return false;
+            }
+
+            int iterations = BinaryPrimitives.ReadInt32BigEndian(hashBytes.AsSpan(1, sizeof(int)));
+            if (iterations <= 0)
+            {
+                return false;
+            }
+
+            byte[] salt = new byte[SaltSize];
+            Buffer.BlockCopy(hashBytes, 1 + sizeof(int), salt, 0, SaltSize);
+
+            byte[] storedSubKey = new byte[KeySize];
+            Buffer.BlockCopy(hashBytes, 1 + sizeof(int) + SaltSize, storedSubKey, 0, KeySize);
+
+            try
+            {
+                using var pbkdf2 = new Rfc2898DeriveBytes(password, salt, iterations, HashAlgorithmName.SHA256);
+                byte[] generatedSubKey = pbkdf2.GetBytes(KeySize);
+
+                verified = CryptographicOperations.FixedTimeEquals(storedSubKey, generatedSubKey);
+                return true;
+            }
+            catch (CryptographicException)
+            {
+                return false;
             }
         }
 
-        /// Verifies a plaintext password against the stored Base64-encoded salt and hash.
-        public static bool VerifyPassword(string password, string storedHash)
+        private static string HashPasswordLegacy(string password)
         {
-            if (string.IsNullOrWhiteSpace(password))
-                return false;
-
-            if (string.IsNullOrWhiteSpace(storedHash))
-                return false;
-
-            // Extract the bytes from the stored hash.
-            byte[] hashBytes = Convert.FromBase64String(storedHash);
-
-            // The salt is the first 16 bytes.
-            byte[] salt = new byte[16];
-            Array.Copy(hashBytes, 0, salt, 0, salt.Length);
-
-            // Generate a hash from the provided password using the same salt and iteration count.
-            using (var pbkdf2 = new Rfc2898DeriveBytes(password, salt, 10000, HashAlgorithmName.SHA256))
+            using SHA256 sha256Hash = SHA256.Create();
+            byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(password));
+            StringBuilder builder = new StringBuilder(bytes.Length * 2);
+            for (int i = 0; i < bytes.Length; i++)
             {
-                byte[] hash = pbkdf2.GetBytes(32);
-
-                // Compare the computed hash with the stored hash.
-                for (int i = 0; i < hash.Length; i++)
-                {
-                    if (hashBytes[i + salt.Length] != hash[i])
-                        return false;
-                }
-                return true;
+                builder.Append(bytes[i].ToString("x2"));
             }
+            return builder.ToString();
         }
     }
 }

--- a/Backer.Web/Controllers/AuthController.cs
+++ b/Backer.Web/Controllers/AuthController.cs
@@ -40,10 +40,7 @@ namespace Backer.Web.Controllers
                     return Ok(ResponseProvider.GetRespone(ResponseState.Failed, "نام کاربری وارد شده نامعتبر می باشد"));
                 }
 
-                // IMPORTANT: In a real application, NEVER store or compare plaintext passwords.
-                // Always hash and salt the password (e.g., using BCrypt) and then compare.
-                var hashPassword = _tokenService.HashPassword(model.Password);
-                if (user.Password != hashPassword)
+                if (!_tokenService.VerifyPassword(model.Password, user.Password))
                 {
                     // Invalid credentials; return an Unauthorized result.
                     return Ok(ResponseProvider.GetRespone(ResponseState.Failed, "رمز عبور وارد شده نامعتبر می باشد"));

--- a/Backer.sln
+++ b/Backer.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backer.Web", "Backer.Web\Ba
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backer.Utilities", "Backer.Utilities\Backer.Utilities.csproj", "{0ED80950-D151-4497-868A-941325C352B2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backer.Web.Tests", "tests\Backer.Web.Tests\Backer.Web.Tests.csproj", "{1A4F4850-4504-4DB5-B0ED-BA262FAC83A6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,19 +41,24 @@ Global
 		{0CE6294B-F0BF-406F-9EE8-45F6115F7E21}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0CE6294B-F0BF-406F-9EE8-45F6115F7E21}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0CE6294B-F0BF-406F-9EE8-45F6115F7E21}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0ED80950-D151-4497-868A-941325C352B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0ED80950-D151-4497-868A-941325C352B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0ED80950-D151-4497-868A-941325C352B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0ED80950-D151-4497-868A-941325C352B2}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+                {0ED80950-D151-4497-868A-941325C352B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0ED80950-D151-4497-868A-941325C352B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0ED80950-D151-4497-868A-941325C352B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0ED80950-D151-4497-868A-941325C352B2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {1A4F4850-4504-4DB5-B0ED-BA262FAC83A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1A4F4850-4504-4DB5-B0ED-BA262FAC83A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1A4F4850-4504-4DB5-B0ED-BA262FAC83A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1A4F4850-4504-4DB5-B0ED-BA262FAC83A6}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
+        GlobalSection(NestedProjects) = preSolution
 		{E00DC1A7-2E43-430B-9742-23D9FBC64ACA} = {A5F47403-8024-403C-A127-25DD44E63213}
 		{ADB0316C-AAE1-4703-A9F3-E60400B6BBB1} = {A5F47403-8024-403C-A127-25DD44E63213}
-		{2F68A5EB-CB73-46B8-81DD-F28439C85F30} = {A5F47403-8024-403C-A127-25DD44E63213}
-		{0CE6294B-F0BF-406F-9EE8-45F6115F7E21} = {A5F47403-8024-403C-A127-25DD44E63213}
-		{0ED80950-D151-4497-868A-941325C352B2} = {A5F47403-8024-403C-A127-25DD44E63213}
-	EndGlobalSection
+                {2F68A5EB-CB73-46B8-81DD-F28439C85F30} = {A5F47403-8024-403C-A127-25DD44E63213}
+                {0CE6294B-F0BF-406F-9EE8-45F6115F7E21} = {A5F47403-8024-403C-A127-25DD44E63213}
+                {0ED80950-D151-4497-868A-941325C352B2} = {A5F47403-8024-403C-A127-25DD44E63213}
+                {1A4F4850-4504-4DB5-B0ED-BA262FAC83A6} = {F16A3446-5593-4F05-8CF5-4BF78E1CC62F}
+        EndGlobalSection
 EndGlobal

--- a/tests/Backer.Web.Tests/AuthControllerTests.cs
+++ b/tests/Backer.Web.Tests/AuthControllerTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Backer.Application.Features.Users.Dtos;
+using Backer.Core.Entities;
+using Backer.Core.Interfaces;
+using Backer.Utilities;
+using Backer.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace Backer.Web.Tests;
+
+public class AuthControllerTests
+{
+    private readonly Mock<ITokenService> _tokenServiceMock = new();
+    private readonly Mock<IRepository<User>> _userRepositoryMock = new();
+    private readonly IConfiguration _configuration = new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string>
+        {
+            ["Jwt:TokenValidityInMinutes"] = "60",
+        })
+        .Build();
+
+    [Fact]
+    public async Task Login_ReturnsToken_WhenCredentialsAreValid()
+    {
+        // Arrange
+        var request = new LoginRequestModel("username", "password");
+        var storedUser = CreateUser("username", "hashed");
+
+        _userRepositoryMock
+            .Setup(repo => repo.FindAsync(
+                It.IsAny<Expression<Func<User, bool>>>(),
+                It.IsAny<Expression<Func<User, object>>[]>()))
+            .ReturnsAsync(new[] { storedUser });
+
+        _tokenServiceMock
+            .Setup(service => service.VerifyPassword(request.Password, storedUser.Password))
+            .Returns(true);
+
+        _tokenServiceMock
+            .Setup(service => service.GenerateToken(storedUser.Username))
+            .Returns("generated-token");
+
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var controller = CreateController(cache);
+
+        // Act
+        var result = await controller.Login(request);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(okResult.Value);
+
+        var successProperty = okResult.Value!.GetType().GetProperty("success");
+        Assert.NotNull(successProperty);
+        Assert.True((bool)successProperty!.GetValue(okResult.Value)!);
+
+        var tokenProperty = okResult.Value.GetType().GetProperty("token");
+        Assert.Equal("generated-token", tokenProperty?.GetValue(okResult.Value));
+
+        _tokenServiceMock.Verify(service => service.VerifyPassword(request.Password, storedUser.Password), Times.Once);
+        _tokenServiceMock.Verify(service => service.GenerateToken(storedUser.Username), Times.Once);
+    }
+
+    [Fact]
+    public async Task Login_ReturnsFailedResponse_WhenPasswordIsInvalid()
+    {
+        // Arrange
+        var request = new LoginRequestModel("username", "wrong-password");
+        var storedUser = CreateUser("username", "hashed");
+
+        _userRepositoryMock
+            .Setup(repo => repo.FindAsync(
+                It.IsAny<Expression<Func<User, bool>>>(),
+                It.IsAny<Expression<Func<User, object>>[]>()))
+            .ReturnsAsync(new[] { storedUser });
+
+        _tokenServiceMock
+            .Setup(service => service.VerifyPassword(request.Password, storedUser.Password))
+            .Returns(false);
+
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var controller = CreateController(cache);
+
+        // Act
+        var result = await controller.Login(request);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<Respone>(okResult.Value);
+
+        Assert.Equal(ResponseState.Failed, response.State);
+        Assert.Equal("رمز عبور وارد شده نامعتبر می باشد", response.Data);
+
+        _tokenServiceMock.Verify(service => service.VerifyPassword(request.Password, storedUser.Password), Times.Once);
+        _tokenServiceMock.Verify(service => service.GenerateToken(It.IsAny<string>()), Times.Never);
+    }
+
+    private AuthController CreateController(IMemoryCache cache)
+    {
+        return new AuthController(_tokenServiceMock.Object, _userRepositoryMock.Object, cache, _configuration);
+    }
+
+    private static User CreateUser(string username, string password)
+    {
+        return new User
+        {
+            Username = username,
+            Password = password,
+            BeginDate = DateTime.UtcNow,
+            JobId = 1,
+            Fullname = "Full Name"
+        };
+    }
+}

--- a/tests/Backer.Web.Tests/Backer.Web.Tests.csproj
+++ b/tests/Backer.Web.Tests/Backer.Web.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Backer.Application\Backer.Application.csproj" />
+    <ProjectReference Include="..\..\Backer.Core\Backer.Core.csproj" />
+    <ProjectReference Include="..\..\Backer.Utilities\Backer.Utilities.csproj" />
+    <ProjectReference Include="..\..\Backer.Web\Backer.Web.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Backer.Web.Tests/TokenUtilityTests.cs
+++ b/tests/Backer.Web.Tests/TokenUtilityTests.cs
@@ -1,0 +1,43 @@
+using System.Security.Cryptography;
+using System.Text;
+using Backer.Utilities;
+using Xunit;
+
+namespace Backer.Web.Tests;
+
+public class TokenUtilityTests
+{
+    [Fact]
+    public void HashPassword_GeneratesVerifiableHash()
+    {
+        var password = "Pa$$w0rd!";
+
+        var hash = TokenUtility.HashPassword(password);
+
+        Assert.True(TokenUtility.VerifyPassword(password, hash));
+        Assert.False(TokenUtility.VerifyPassword("incorrect", hash));
+    }
+
+    [Fact]
+    public void VerifyPassword_SupportsLegacySha256Hashes()
+    {
+        var password = "legacy";
+        var legacyHash = ComputeLegacyHash(password);
+
+        Assert.True(TokenUtility.VerifyPassword(password, legacyHash));
+        Assert.False(TokenUtility.VerifyPassword("wrong", legacyHash));
+    }
+
+    private static string ComputeLegacyHash(string password)
+    {
+        using var sha256 = SHA256.Create();
+        byte[] bytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(password));
+        var builder = new StringBuilder(bytes.Length * 2);
+        foreach (byte b in bytes)
+        {
+            builder.Append(b.ToString("x2"));
+        }
+
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
## Summary
- replace the legacy SHA-256 password hashing with a PBKDF2-based payload that keeps compatibility with existing hashes
- update the authentication controller to rely on the token service's password verification helper instead of hashing comparisons
- add a dedicated Backer.Web.Tests project with coverage for the new hashing logic and login success/failure paths

## Testing
- `dotnet test` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d918e6106c8327a55f2c95249a5e07